### PR TITLE
deal with spaces in header

### DIFF
--- a/lib/rightmove_blm/document.rb
+++ b/lib/rightmove_blm/document.rb
@@ -28,10 +28,10 @@ module RightmoveBLM
       @header ||= contents(:header).each_line.map do |line|
         next nil if line.empty?
 
-        key, _, value = line.partition(' : ')
+        key, _, value = line.partition(':')
         next nil if value.nil?
 
-        [key.downcase.to_sym, value.tr("'", '').strip]
+        [key.strip.downcase.to_sym, value.tr("'", '').strip]
       end.compact.to_h
     end
 

--- a/spec/blm_spec.rb
+++ b/spec/blm_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RightmoveBLM do
 
     it 'should parse settings from the header' do
       expect(blm.header).to be_a(Hash)
-      expect(blm.header[:version]).to_not be_nil
+      expect(blm.header[:version]).to  eq("3")
       expect(blm.header[:eof]).to_not be_nil
       expect(blm.header[:eor]).to_not be_nil
     end

--- a/spec/fixtures/example_data.blm
+++ b/spec/fixtures/example_data.blm
@@ -1,5 +1,5 @@
 #HEADER#
-VERSION : 3
+VERSION: 3
 EOF : '|'
 EOR : '~'
 


### PR DESCRIPTION
Actions:

+ strip the key to remove unnecessary spaces.

+ partition by : instead of " : ".