### PR TITLE
wrong content end point

### DIFF
--- a/lib/rightmove_blm/document.rb
+++ b/lib/rightmove_blm/document.rb
@@ -86,7 +86,7 @@ module RightmoveBLM
     def contents(section = :data)
       marker = "##{section.to_s.upcase}#"
       start = verify(:start, @source.index(marker)) + marker.size
-      finish = verify(:end, @source.index('#', start)) - 1
+      finish = verify(:end, @source.index('#END#', start)) - 1
       @source[start..finish].strip
     end
 

--- a/lib/rightmove_blm/version.rb
+++ b/lib/rightmove_blm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RightmoveBLM
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
Actions:

+ set content end point to #END#.

Motivations:

+ If a file contains data with # in it that will be considered end of the file and no more data will be parsed from the file, we want #END# to be considered end of the file.