### PR TITLE
Add file structure verification for documents with source files.

### DIFF
--- a/rightmove_blm.gemspec
+++ b/rightmove_blm.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary
   spec.description = 'Parse and generate Rightmove BLM files'
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 2.7.1'
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }

--- a/spec/fixtures/blm_with_wrong_structure.blm
+++ b/spec/fixtures/blm_with_wrong_structure.blm
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<clients>
+   <client id="55000">
+      <name>Charter Group</name>
+   </client>
+</clients>

--- a/spec/rightmove_blm_spec.rb
+++ b/spec/rightmove_blm_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe RightmoveBLM do
         rows.each { |row| expect(row.attributes).to be_a(Hash) }
       end
     end
+
+    describe 'with invalid file structure' do
+      let(:blm_data) { fixture('blm_with_wrong_structure.blm') }
+
+      describe '#initialize' do
+        err_msg = "<#RightmoveBLM::Document>: Unable to process document with this structure: could not detect HEADER marker. "
+
+        it { expect { blm }.to raise_error(RightmoveBLM::ParserError,  err_msg) }
+      end
+    end
   end
 
   context 'when creating a .blm file' do


### PR DESCRIPTION
Actions:

Add document file structure verification. Update tests.

Motivation:

It looks like BLM file verification would come in handy when someone would try to parse file with `.BLM/.blm` extension but invalid file structure.