### PR TITLE
Cut blm file validations to look only for file sections.

### DIFF
--- a/lib/rightmove_blm/document.rb
+++ b/lib/rightmove_blm/document.rb
@@ -3,7 +3,7 @@
 module RightmoveBLM
   # A BLM document including its header, definition, and data content.
   class Document # rubocop:disable Metrics/ClassLength
-    BLM_4_FILE_KEYWORDS = %w[HEADER VERSION EOF EOR DEFINITION DATA END].freeze
+    BLM_FILE_SECTIONS = %w[HEADER DEFINITION DATA END].freeze
 
     def self.from_array_of_hashes(array)
       date = Time.now.utc.strftime('%d-%b-%Y %H:%M').upcase
@@ -117,10 +117,10 @@ module RightmoveBLM
     end
 
     def verify_source_file_structure(source)
-      BLM_4_FILE_KEYWORDS.each do |keyword|
-        next if source.index(keyword)
+      BLM_FILE_SECTIONS.each do |section|
+        next if source.index(section)
 
-        raise_parser_error "Unable to process document with this structure: could not detect #{keyword} marker."
+        raise_parser_error "Unable to process document with this structure: could not detect #{section} section."
       end
     end
 

--- a/lib/rightmove_blm/version.rb
+++ b/lib/rightmove_blm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RightmoveBLM
-  VERSION = '0.2.6'
+  VERSION = '0.2.7'
 end

--- a/spec/rightmove_blm_spec.rb
+++ b/spec/rightmove_blm_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RightmoveBLM do
         it do
           expect { blm }.to raise_error RightmoveBLM::ParserError,
                                         '<#RightmoveBLM::Document>: Unable to process document ' \
-                                        'with this structure: could not detect HEADER marker. '
+                                        'with this structure: could not detect HEADER section. '
         end
       end
     end


### PR DESCRIPTION
Actions:

+ Change keywords required for file validation only to section names.

+ Error message update.

Motivation:

+ At this point we don't need anything fancy in order to validate blm files structure so plain section names checking would do the thing.

+ May be a bit overengineering, but file structure validation may benefit from keywords order check to exclude section displacement. No practical case - may be irrelevant.