### PR TITLE
Create BLM document with version `3i`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,9 @@ The keys from the first _hash_ in the provided _array_ are used to provide the f
 document = RightmoveBLM::Document.from_array_of_hashes([{ field1: 'foo', field2: 'bar' }, { field1: 'baz', field2: 'foobar' }])
 File.write('my_data.blm', document.to_blm)
 ```
+
+To generate a Rightmove document with version 3i, provide `true` for the optional parameter `international`.
+
+```ruby
+document = RightmoveBLM::Document.from_array_of_hashes([{ field1: 'foo', field2: 'bar' }, { field1: 'baz', field2: 'foobar' }], international: true)
+```

--- a/lib/rightmove_blm/document.rb
+++ b/lib/rightmove_blm/document.rb
@@ -5,9 +5,10 @@ module RightmoveBLM
   class Document # rubocop:disable Metrics/ClassLength
     BLM_FILE_SECTIONS = %w[HEADER DEFINITION DATA END].freeze
 
-    def self.from_array_of_hashes(array)
+    def self.from_array_of_hashes(array, international: false)
       date = Time.now.utc.strftime('%d-%b-%Y %H:%M').upcase
-      header = { version: '3', eof: '^', eor: '~', 'property count': array.size.to_s, 'generated date': date }
+      version = international ? '3i' : '3'
+      header = { version: version, eof: '^', eor: '~', 'property count': array.size.to_s, 'generated date': date }
       new(header: header, definition: array.first.keys.map(&:to_sym), data: array)
     end
 

--- a/lib/rightmove_blm/version.rb
+++ b/lib/rightmove_blm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RightmoveBLM
-  VERSION = '0.2.8'
+  VERSION = '0.2.9'
 end


### PR DESCRIPTION
Actions:

+ Added an optional argument `international` to RightmoveBLM::Document

Motivations:

+ When blm document is generated for international properties, it required to have version `3i`.