### PR TITLE
Updated gem version.

### DIFF
--- a/lib/rightmove_blm/version.rb
+++ b/lib/rightmove_blm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RightmoveBLM
-  VERSION = '0.2.9'
+  VERSION = '0.2.10'
 end


### PR DESCRIPTION
Changes were made in https://github.com/bobf/rightmove_blm/pull/9, missed to update the version of the gem. So creating a new PR to update gem version.